### PR TITLE
Fix bug: when file has success downloaded and  invoke [download: didF…

### DIFF
--- a/Example/TCBlobDownloadExample/SimpleViewController/SimpleViewController.m
+++ b/Example/TCBlobDownloadExample/SimpleViewController/SimpleViewController.m
@@ -49,7 +49,8 @@
                                        firstResponse:NULL
                                             progress:^(uint64_t receivedLength, uint64_t totalLength, NSInteger remainingTime, float progress) {
                                                 if (remainingTime != -1) {
-                                                    [self.remainingTime setText:[NSString stringWithFormat:@"%lds", (long)remainingTime]];
+                                                    NSLog(@"%f", progress);
+                                                    [self.remainingTime setText:[NSString stringWithFormat:@"%.0f%%", progress * 100]];
                                                 }
                                             }
                                                error:^(NSError *error) {

--- a/Example/TCBlobDownloadExample/TCBlobDownloadExample-Info.plist
+++ b/Example/TCBlobDownloadExample/TCBlobDownloadExample-Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/TCBlobDownload/TCBlobDownload/TCBlobDownloader.h
+++ b/TCBlobDownload/TCBlobDownload/TCBlobDownloader.h
@@ -103,6 +103,12 @@ typedef NS_ENUM(NSUInteger, TCBlobDownloadState) {
 @property (nonatomic, copy, readonly, getter = pathToFile) NSString *pathToFile;
 
 /**
+ *  下载完成的文件路径，`pathToFile` 下载部分文件路径。
+ *  该库在一个文件完成下载后，如果重新发起下载请求，会产生 HTTP `416` 错误
+ */
+@property (nonatomic, copy, readonly, getter = pathToCompletedFile) NSString *pathToCompletedFile;
+
+/**
  The URL of the file to download.
  
  @warning You should not set this property directly, as it is managed by the initialization method.

--- a/TCBlobDownload/TCBlobDownload/TCBlobDownloader.m
+++ b/TCBlobDownload/TCBlobDownload/TCBlobDownloader.m
@@ -330,6 +330,10 @@ NSString * const TCBlobDownloadErrorHTTPStatusKey = @"TCBlobDownloadErrorHTTPSta
 {
     BOOL success = error == nil;
     
+    // Finish the operation
+    TCBlobDownloadState finalState = success ? TCBlobDownloadStateDone : TCBlobDownloadStateFailed;
+    [self finishOperationWithState:finalState];
+    
     // Notify from error if any
     if (error) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -352,9 +356,7 @@ NSString * const TCBlobDownloadErrorHTTPStatusKey = @"TCBlobDownloadErrorHTTPSta
         }
     });
     
-    // Finish the operation
-    TCBlobDownloadState finalState = success ? TCBlobDownloadStateDone : TCBlobDownloadStateFailed;
-    [self finishOperationWithState:finalState];
+    
 }
 
 - (void)updateTransferRate


### PR DESCRIPTION
Fix bug: when file has success downloaded and  invoke the delegate method [download: didFinishWithSuccess: atPath:], but the `state` value still is TCBlobDownloadStateDownloading.
